### PR TITLE
Remove babel-polyfill to reduce bundle file size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('babel-polyfill');
 require('babel-register');
 
 if (process.env.NODE_ENV === 'production') {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "devel": "npm run tests & npm run watch & npm run server",
     "tests": "nodemon -w src -w spec -e js,html,css --no-colors -q -x 'npm test'",
     "server": "nodemon -w src -w spec/api.yaml -e js,html,css --no-colors -q index.js",
-    "watch": "watchify -d -r babel-polyfill -t babelify -p [css-modulesify --after postcss-cssnext -o dist/main.css] -o dist/main.js src/client.js",
-    "prestart": "NODE_ENV=production browserify -r babel-polyfill -t babelify -g envify -g [uglifyify -x .js] -p [css-modulesify --after postcss-cssnext --after csswring -o dist/main.css] -o dist/main.js src/client.js"
+    "watch": "watchify -d -t babelify -p [css-modulesify --after postcss-cssnext -o dist/main.css] -o dist/main.js src/client.js",
+    "prestart": "NODE_ENV=production browserify -t babelify -g envify -g [uglifyify -x .js] -p [css-modulesify --after postcss-cssnext --after csswring -o dist/main.css] -o dist/main.js src/client.js"
   },
   "repository": {
     "type": "git",
@@ -40,7 +40,6 @@
     "babel-core": "6.4.5",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-strict-mode": "6.3.13",
-    "babel-polyfill": "6.3.14",
     "babel-preset-es2015": "6.3.13",
     "babel-preset-react": "6.3.13",
     "babel-preset-stage-0": "6.3.13",


### PR DESCRIPTION
In case we actually need a polyfill we should only import the required
polyfill directly: https://github.com/zloirock/core-js#commonjs
